### PR TITLE
Fixed .editorconfig to eliminate warnings on comment blocks.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,15 @@
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.js]
+indent_size = 2
+block_comment_start = /*
+block_comment = *
+block_comment_end = */
+
 [*.py]
 indent_size = 4
-


### PR DESCRIPTION
Allow for:

```c++
/*
 * Comment.
 */
```

and not be warned about 1 character indents.
See https://github.com/jedmao/eclint/issues/149