### PR TITLE
Do not advertise service.

### DIFF
--- a/characteristic_read/device_code.js
+++ b/characteristic_read/device_code.js
@@ -29,7 +29,7 @@ function onInit() {
         description: 'Single read-only characteristic',
       }
     }
-  }, { advertise: ['0b30acec-193e-11eb-adc1-0242ac120002'] });
+  });
 
   NRF.on('disconnect', (addr) => {
     // Provide feedback that device no longer connected.


### PR DESCRIPTION
Remove the parameter to explicitly advertize the test service
on the device. This was thought to be necessary, but is not,
and is causing `onInit()` to fail.