### PR TITLE
Adjust dark-mode hyperlink styles.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -29,7 +29,7 @@ body {
   }
 
   a:visited {
-    color: #b18af8 ;
+    color: #b18af8;
   }
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -23,6 +23,14 @@ body {
   .pass {
     color: lightgreen;
   }
+
+  a {
+    color: #8AB4F8;
+  }
+
+  a:visited {
+    color: #b18af8 ;
+  }
 }
 
 .flex {


### PR DESCRIPTION
The anchor color in dark mode had low contrast with the body
color. Made the colors lighter to improve readability.