### PR TITLE
Improved message when Bluetooth not available.

### DIFF
--- a/characteristic_notify/index.html
+++ b/characteristic_notify/index.html
@@ -62,8 +62,14 @@
     <p>Status: <span id='test_result'></span></p>
     <pre id='status'></pre>
   </div>
-  <div id="no_bluetooth" style="visibility: hidden;">
-    This browser does not support Bluetooth.
+  <!-- Only one of the two below will be visible. -->
+  <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available.
+  </div>
+  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires HTTPS. For development
+    purposes it does support HTTP, but only the on the loopback adapter
+    (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_notify/index.html
+++ b/characteristic_notify/index.html
@@ -66,10 +66,10 @@
   <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
     Bluetooth is not available.
   </div>
-  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
-    Bluetooth is not available. Bluetooth requires HTTPS. For development
-    purposes it does support HTTP, but only the on the loopback adapter
-    (i.e. "localhost").
+  <div id="insecure_context" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires a secure context (HTTPS).
+    For development purposes it does support HTTP, but only the on the loopback
+    adapter (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_notify/web_app.js
+++ b/characteristic_notify/web_app.js
@@ -134,10 +134,10 @@ function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
     $('have_bluetooth').style.display = 'none';
-    if (window.location.protocol == 'https') {
+    if (window.isSecureContext == 'https') {
       $('no_bluetooth').style.visibility = 'visible';
     } else {
-      $('no_https').style.visibility = 'visible';
+      $('insecure_context').style.visibility = 'visible';
     }
   }
 }

--- a/characteristic_notify/web_app.js
+++ b/characteristic_notify/web_app.js
@@ -133,7 +133,11 @@ async function startTest() {
 function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
-    $('no_bluetooth').style.visibility = 'visible';
     $('have_bluetooth').style.display = 'none';
+    if (window.location.protocol == 'https') {
+      $('no_bluetooth').style.visibility = 'visible';
+    } else {
+      $('no_https').style.visibility = 'visible';
+    }
   }
 }

--- a/characteristic_read/index.html
+++ b/characteristic_read/index.html
@@ -62,8 +62,14 @@
     <p>Status: <span id='test_result'></span></p>
     <pre id='status'></pre>
   </div>
-  <div id="no_bluetooth" style="visibility: hidden;">
-    This browser does not support Bluetooth.
+  <!-- Only one of the two below will be visible. -->
+  <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available.
+  </div>
+  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires HTTPS. For development
+    purposes it does support HTTP, but only the on the loopback adapter
+    (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_read/index.html
+++ b/characteristic_read/index.html
@@ -66,10 +66,10 @@
   <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
     Bluetooth is not available.
   </div>
-  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
-    Bluetooth is not available. Bluetooth requires HTTPS. For development
-    purposes it does support HTTP, but only the on the loopback adapter
-    (i.e. "localhost").
+  <div id="insecure_context" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires a secure context (HTTPS).
+    For development purposes it does support HTTP, but only the on the loopback
+    adapter (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_read/web_app.js
+++ b/characteristic_read/web_app.js
@@ -92,7 +92,11 @@ async function startTest() {
 function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
-    $('no_bluetooth').style.visibility = 'visible';
     $('have_bluetooth').style.display = 'none';
+    if (window.location.protocol == 'https') {
+      $('no_bluetooth').style.visibility = 'visible';
+    } else {
+      $('no_https').style.visibility = 'visible';
+    }
   }
 }

--- a/characteristic_read/web_app.js
+++ b/characteristic_read/web_app.js
@@ -93,10 +93,10 @@ function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
     $('have_bluetooth').style.display = 'none';
-    if (window.location.protocol == 'https') {
+    if (window.isSecureContext == 'https') {
       $('no_bluetooth').style.visibility = 'visible';
     } else {
-      $('no_https').style.visibility = 'visible';
+      $('insecure_context').style.visibility = 'visible';
     }
   }
 }

--- a/characteristic_readwrite/index.html
+++ b/characteristic_readwrite/index.html
@@ -62,8 +62,14 @@
     <p>Status: <span id='test_result'></span></p>
     <pre id='status'></pre>
   </div>
-  <div id="no_bluetooth" style="visibility: hidden;">
-    This browser does not support Bluetooth.
+  <!-- Only one of the two below will be visible. -->
+  <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available.
+  </div>
+  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires HTTPS. For development
+    purposes it does support HTTP, but only the on the loopback adapter
+    (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_readwrite/index.html
+++ b/characteristic_readwrite/index.html
@@ -66,10 +66,10 @@
   <div id="no_bluetooth" class="no-bluetooth" style="visibility: hidden;">
     Bluetooth is not available.
   </div>
-  <div id="no_https" class="no-bluetooth" style="visibility: hidden;">
-    Bluetooth is not available. Bluetooth requires HTTPS. For development
-    purposes it does support HTTP, but only the on the loopback adapter
-    (i.e. "localhost").
+  <div id="insecure_context" class="no-bluetooth" style="visibility: hidden;">
+    Bluetooth is not available. Bluetooth requires a secure context (HTTPS).
+    For development purposes it does support HTTP, but only the on the loopback
+    adapter (i.e. "localhost").
   </div>
 </body>
 

--- a/characteristic_readwrite/web_app.js
+++ b/characteristic_readwrite/web_app.js
@@ -101,10 +101,10 @@ function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
     $('have_bluetooth').style.display = 'none';
-    if (window.location.protocol == 'https') {
+    if (window.isSecureContext == 'https') {
       $('no_bluetooth').style.visibility = 'visible';
     } else {
-      $('no_https').style.visibility = 'visible';
+      $('insecure_context').style.visibility = 'visible';
     }
   }
 }

--- a/characteristic_readwrite/web_app.js
+++ b/characteristic_readwrite/web_app.js
@@ -100,7 +100,11 @@ async function startTest() {
 function init() {
   if (!isBluetoothSupported()) {
     console.log('Bluetooth not supported.');
-    $('no_bluetooth').style.visibility = 'visible';
     $('have_bluetooth').style.display = 'none';
+    if (window.location.protocol == 'https') {
+      $('no_bluetooth').style.visibility = 'visible';
+    } else {
+      $('no_https').style.visibility = 'visible';
+    }
   }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -34,7 +34,7 @@ body {
   padding: 10px;
 }
 
-#no_bluetooth {
+.no-bluetooth {
   font-size: larger;
   color: red;
 }


### PR DESCRIPTION
Using a different error message when Bluetooth is unavailable
and the scheme is insecure (http). This should help developers that
overlooked the fact that HTTPS is required in most cases.