### PR TITLE
Always set display=true when calling NRF.setSecurity.

### DIFF
--- a/characteristic_secure/device_code.js
+++ b/characteristic_secure/device_code.js
@@ -24,6 +24,13 @@ const devicePassKey = '121212'; // 6 digit passkey to use.
 let isConnected = false;
 let debug = '?';
 
+function canShowPasskey() {
+  // Without a display this app cannot actually display a passkey, but return
+  // true because this is required in order to pair using passkeys.
+  // http://forum.espruino.com/comments/14922430/
+  return true;
+}
+
 function deviceHasDisplay() {
   return typeof g !== 'undefined';
 }
@@ -130,9 +137,9 @@ function onInit() {
   });
 
   NRF.setSecurity({
-    display: deviceHasDisplay(),  // Can this device display a passkey?
-    keyboard: false,              // Can this device enter a passkey?
-    mitm: true,                   // Man In The Middle protection.
+    display: canShowPasskey(),  // Can this device display a passkey?
+    keyboard: false,            // Can this device enter a passkey?
+    mitm: true,                 // Man In The Middle protection.
     passkey: devicePassKey,
   });
 


### PR DESCRIPTION
If the `passkey` option is true then so must `display`. This does
not mean that the device needs to have a display - only that the
passkey is somehow displayed to the user for device identification.

This is only a test, so hard-code to true.